### PR TITLE
Added code to calculate total scan sizes for each project and version.  Updated .gitignore to avoid .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#vscode
+.vscode

--- a/sage.py
+++ b/sage.py
@@ -215,13 +215,18 @@ class BlackDuckSage(object):
                     high_freq_scans.append(scan)
         self.data['high_frequency_scans'] = high_freq_scans
 
-    def _calc_project_scan_size(self):
+    # Calculate the total scan size for all scans in each vesion and all versions in a project.
+    # Add 'scanSize' data to each project and version object with the results.
+    def _calc_scan_sizes(self):
         for p in self.data['projects']:
-            scan_size = 0
+            project_scan_size = 0
             for v in p['versions']:
+                version_scan_size=0
                 for scan in v['scans']:
-                    scan_size += scan['scanSize']
-            p['project_scan_size'] = scan_size
+                    version_scan_size += scan['scanSize']
+                v['scanSize'] = version_scan_size
+                project_scan_size += version_scan_size
+            p['scanSize'] = project_scan_size
 
     def _analyze_jobs(self):
         url = self.hub.get_apibase() + "/job-statistics"
@@ -235,7 +240,7 @@ class BlackDuckSage(object):
         self._get_data()
 
         logging.debug("Analyzing data")
-        self._calc_project_scan_size()
+        self._calc_scan_sizes()
         self._find_projects_with_too_many_versions()
         self._find_versions_with_too_many_scans()
         self._find_versions_with_zero_scans()

--- a/sage.py
+++ b/sage.py
@@ -215,6 +215,14 @@ class BlackDuckSage(object):
                     high_freq_scans.append(scan)
         self.data['high_frequency_scans'] = high_freq_scans
 
+    def _calc_project_scan_size(self):
+        for p in self.data['projects']:
+            scan_size = 0
+            for v in p['versions']:
+                for scan in v['scans']:
+                    scan_size += scan['scanSize']
+            p['project_scan_size'] = scan_size
+
     def _analyze_jobs(self):
         url = self.hub.get_apibase() + "/job-statistics"
         response = self.hub.execute_get(url)
@@ -227,6 +235,7 @@ class BlackDuckSage(object):
         self._get_data()
 
         logging.debug("Analyzing data")
+        self._calc_project_scan_size()
         self._find_projects_with_too_many_versions()
         self._find_versions_with_too_many_scans()
         self._find_versions_with_zero_scans()


### PR DESCRIPTION
Added  _calc_scan_sizes() to calculate total scan sizes for each project and version, then insert the results into each project and version object.  The intent is to allow users to find projects and/or versions that are using a lot of space.

The resulting output can be turned into a CSV file with project name and scan size using this JQ command:
jq -r '.projects[] ^| .name + ", " + (.scanSize ^| tostring)' < sage_says.json > sizes.csv

If this PR is accepted, the jq command should be considered for addition to the documentation page.

Also updated .gitignore to avoid .vscode directory for VS Code users.