### PR TITLE
Allow credentials or a token file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Analyze usage of a Black Duck system and offer sage advice for how to improve us
 Sage uses:
 
 - Python3
-- An API token from your Black Duck server
+- Credentials or an API token from your Black Duck server
   - The user account this token is issued from needs to have visibility to all the projects, versions, and scans you want to analyze, e.g. has role 'Systemadmin', 'Super User', or 'Global Code Scanner'
 - Highly recommended: [virtualenv](https://virtualenv.pypa.io/en/latest/), [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)
 

--- a/sage.py
+++ b/sage.py
@@ -317,6 +317,10 @@ Resuming requires a previously saved file is present to read the current state o
 
     args = parser.parse_args()
 
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     create_config = False
     if (create_config): logging.info("writing .restconfig.json upon successful authentication")
 
@@ -340,10 +344,6 @@ Resuming requires a previously saved file is present to read the current state o
             sys.exit(-1)
         logging.info("reading authentication details from .restconfig.json")
         hub = HubInstance()
-
-    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
-    logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     sage = BlackDuckSage(
         hub, 


### PR DESCRIPTION
Instead of just providing a token, optionally allow credentials to be provided at the command-line.

For example allow:
$ python3 sage.py https://example.com --username sysadmin --password PASSWORD -f sage_says.json
$ python3 sage.py https://example.com --api_token_file token.txt -f sage_says.json

In addition to the original behavior (which I tested still works):
$ python3 sage.py https://example.com API_TOKEN -f sage_says.json