### PR TITLE
Add warning for possible incomplete scan-summaries

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -363,6 +363,12 @@ Resuming requires a previously saved file is present to read the current state o
 
     hub = authenticate_hub(args)
 
+    hub_25835_affected_versions = ['2020.08', '2020.10']
+    for h in hub_25835_affected_versions:
+        if hub.version_info['version'].startswith(h):
+            logging.warning("Scan summaries may be incomplete showing only 1 entry per codelocation (ref. HUB-25835)")
+            logging.warning("Affected Hub versions: %s", hub_25835_affected_versions)
+
     sage = BlackDuckSage(
         hub, 
         mode=args.mode,


### PR DESCRIPTION
In 2020.08 and 2020.10 the codelocations/{}/scan-summaries endpoint only
returns 1 entry even though more may exist. See HUB-25835.

This bug makes it nearly impossible to determine if too frequent scanning to a
given codelocation is occurring.  It is possible to look at the journal events
for a project version but this method is both slow and when codelocations are
mapped/unmapped it is unreliable.

I searched for possible work-arounds in the REST API but did not find any
satisfactory ones and thus the best we can do is provide a warning about the
issue.