### PR TITLE
changing the way we test that the file the user gives us is writeable

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -68,12 +68,20 @@ class BlackDuckSage(object):
         self.data = {}
 
     def _check_file_permissions(self):
+        '''Test that we can write to the file path given and if there is an issue let the user know
+        '''
         f = Path(self.file)
-        if f.exists():
-            if not os.access(self.file, os.W_OK):
-                raise PermissionError("Need write access to file {} in order to save the analysis results".format(self.file))
-        else:
-            open(self.file, "w")  # will fail if we don't have write permissions
+        # Doing this the pythonic way of just opening the file to write and checking for exceptions
+        try:
+            open(self.file, "w")
+        except:
+            if f.is_dir():
+                logging.error(f"Sage must be given a file to write results into, but {self.file} is a directory")
+            elif f.is_file():
+                logging.error(f"Cannot open file {self.file} for writing. Check the file permissions and make sure the user has write privileges")
+            else:
+                logging.error(f"Whoops, not sure what went wrong but we cannot open ({self.file}) for writing")
+            raise
 
     @staticmethod
     def _remove_white_space(message):


### PR DESCRIPTION
This is a fix for issues #27 and #28 which both relate to the file Sage uses to write the results into. Sage can take a long time to run so we want to know before proceeding that we will be able to write the results out to a file when we're done. The method that checks the file permissions (_check_file_permission) had a bug (which this PR hopefully addresses) wherein if the user provides a directory name (which is writeable by the user) it will proceed. Hopefully, the new approach (just try to open the file for writing and look for an exception) will be a more reliable test.

I've tested this on a Mac and on a Windows Server machine to verify the logic.